### PR TITLE
Fixes some small errors that caused the generator scripts to fail depending on the size of the image.

### DIFF
--- a/vae-gan/data/display_image.py
+++ b/vae-gan/data/display_image.py
@@ -23,10 +23,14 @@ import cStringIO
 from PIL import Image
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--image', type=str, default='')
+parser.add_argument('--base64_image', type=str, default='')
 args, _ = parser.parse_known_args()
 
-im = args.image.replace('_', '/').replace('-', '+')
+im = args.base64_image.replace('_', '/').replace('-', '+')
+
+missing_base64_padding = len(im) % 4
+if missing_base64_padding != 0:
+  im += ('=' * (4 - missing_base64_padding))
 
 img = Image.open(cStringIO.StringIO(im.decode('base64')))
 img.show()

--- a/vae-gan/data/generate_image.sh
+++ b/vae-gan/data/generate_image.sh
@@ -57,9 +57,8 @@ fi
 
 JSON_OBJ=$(python create_random_embedding.py)
 
-echo -e "${JSON_OBJ} > "${TMP_FILE}"
+echo -e "${JSON_OBJ}" > "${TMP_FILE}"
 
 OUTPUT=$(gcloud ml-engine predict --model "${MODEL_NAME}" --json-instances "${TMP_FILE}")
-IMAGE=$(echo "${OUTPUT}"| cut -d' ' -f 4)
-
-python display_image.py --image "${IMAGE}"
+IMAGE=$(echo "${OUTPUT}"| awk 'NR==2 {print $2}')
+python display_image.py --base64_image "${IMAGE}"


### PR DESCRIPTION
Fixes a bug causing generate_image.sh to fail on an unterminated string.
Adds padding to the base64 image in display_image.py if necessary. More
safely extracts image data from the CloudML response using awk.